### PR TITLE
Drop PROJ

### DIFF
--- a/.ci_support/linux_64_r_base4.1.yaml
+++ b/.ci_support/linux_64_r_base4.1.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -14,8 +14,6 @@ pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
-proj:
-- 9.1.1
 r_base:
 - '4.1'
 target_platform:

--- a/.ci_support/linux_64_r_base4.2.yaml
+++ b/.ci_support/linux_64_r_base4.2.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -14,8 +14,6 @@ pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
-proj:
-- 9.1.1
 r_base:
 - '4.2'
 target_platform:

--- a/.ci_support/osx_64_r_base4.1.yaml
+++ b/.ci_support/osx_64_r_base4.1.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,8 +14,6 @@ pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
-proj:
-- 9.1.1
 r_base:
 - '4.1'
 target_platform:

--- a/.ci_support/osx_64_r_base4.2.yaml
+++ b/.ci_support/osx_64_r_base4.2.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,8 +14,6 @@ pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
-proj:
-- 9.1.1
 r_base:
 - '4.2'
 target_platform:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nawendt
+* @conda-forge/r @nawendt

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About r-gribr
-=============
+About r-gribr-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/r-gribr-feedstock/blob/main/LICENSE.txt)
 
 Home: http://github.com/nawendt/gribr
 
 Package license: BSD-3-Clause
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/r-gribr-feedstock/blob/main/LICENSE.txt)
 
 Summary: R interface for GRIB files using ECMWF ecCodes.
 
@@ -188,5 +188,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@conda-forge/r](https://github.com/conda-forge/r/)
 * [@nawendt](https://github.com/nawendt/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1a3365eab11989847afbde61ece018557aee8b477f2a5ff124fd955260e49e12
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   rpaths:
     - lib/R/lib/
@@ -22,12 +22,10 @@ requirements:
   host:
     - r-base
     - r-proj4
-    - proj
     - eccodes >=2.19.0
   run:
     - r-base
     - r-proj4
-    - proj
     - eccodes >=2.19.0
 
 test:
@@ -46,4 +44,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - conda-forge/r
     - nawendt


### PR DESCRIPTION
The `proj` dependency appears not to be required since the library never links against it. Dropping it would avoid unnecessary rebuilding each time PROJ gets updated. That is, `r-proj4` will guarantee that PROJ is present and `r-proj4` already rebuilds itself for compatibility with latest versions.

Also suggesting to add **conda-forge/r** team as maintainers (we generally like to help with all R packages).

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
